### PR TITLE
✨ 인증 서비스 기본 유틸리티 추가

### DIFF
--- a/auth-service/build.gradle
+++ b/auth-service/build.gradle
@@ -10,5 +10,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+
+    // JWT 라이브러리
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5' // Jackson을 사용해 JWT를 직렬화/역직렬화
 }
 

--- a/auth-service/src/main/java/com/ticketing/authservice/AuthServiceApplication.java
+++ b/auth-service/src/main/java/com/ticketing/authservice/AuthServiceApplication.java
@@ -2,8 +2,10 @@ package com.ticketing.authservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
+@EnableFeignClients // Feign Clients 활성화
 public class AuthServiceApplication {
 
 	public static void main(String[] args) {

--- a/auth-service/src/main/java/com/ticketing/authservice/application/dto/UserDto.java
+++ b/auth-service/src/main/java/com/ticketing/authservice/application/dto/UserDto.java
@@ -1,0 +1,70 @@
+package com.ticketing.authservice.application.dto;
+
+import com.ticketing.authservice.infrastructure.common.RoleType;
+
+import lombok.Builder;
+import lombok.With;
+
+/**
+ * UserDto는 사용자 정보와 관련된 모든 요청/응답 데이터를 담는 DTO입니다.
+ */
+public interface UserDto { //TODO: 공통모듈 적용시 통합
+
+	/**
+	 * Auth 관련 요청/응답을 담는 인터페이스입니다.
+	 */
+	interface Auth {
+
+		/**
+		 * 로그인 요청을 처리하는 DTO입니다.
+		 *
+		 * @param email 사용자 이메일 주소
+		 * @param password 사용자 비밀번호
+		 */
+		@With
+		@Builder
+		record Login(String email, String password) {
+		}
+
+		/**
+		 * 로그인 결과를 반환하는 DTO입니다. (readUserByEmail의 결과로 사용)
+		 *
+		 * @param id 사용자 ID
+		 * @param name 사용자 이름
+		 * @param email 사용자 이메일 주소
+		 * @param password 사용자 비밀번호 (해시된 비밀번호)
+		 * @param role 사용자 권한 정보
+		 */
+		@With
+		@Builder
+		record Result(Long id, String name, String email, String password, RoleType role) {
+		}
+	}
+
+	/**
+	 * 사용자 정보를 반환하는 DTO입니다.
+	 *
+	 * @param id 사용자 ID
+	 * @param name 사용자 이름
+	 * @param email 사용자 이메일 주소
+	 * @param role 사용자 권한 정보 (RoleType)
+	 */
+	@With
+	@Builder
+	record Result(Long id, String name, String email, RoleType role) {
+	}
+
+	/**
+	 * 사용자 생성 요청을 처리하는 DTO입니다.
+	 *
+	 * @param name 사용자 이름
+	 * @param email 사용자 이메일 주소
+	 * @param password 사용자 비밀번호
+	 * @param phoneNumber 사용자 전화번호
+	 * @param role 사용자 권한 정보
+	 */
+	@With
+	@Builder
+	record Create(String name, String email, String password, String phoneNumber, RoleType role) {
+	}
+}

--- a/auth-service/src/main/java/com/ticketing/authservice/application/mapper/AuthDataMapper.java
+++ b/auth-service/src/main/java/com/ticketing/authservice/application/mapper/AuthDataMapper.java
@@ -1,0 +1,33 @@
+package com.ticketing.authservice.application.mapper;
+
+import java.util.function.Function;
+
+import org.springframework.stereotype.Component;
+
+import com.ticketing.authservice.application.dto.UserDto;
+
+/**
+ * AuthDataMapper는 회원가입 및 로그인과 관련된 데이터를 변환하는 역할을 담당하는 매퍼입니다.
+ */
+@Component
+public class AuthDataMapper {
+
+	/**
+	 * 회원가입 요청 데이터를 받아서 UserDto.Create로 변환합니다.
+	 * 비밀번호 암호화는 람다로 전달받아 처리합니다.
+	 *
+	 * @param create 회원가입 요청 데이터를 담은 UserDto.Create
+	 * @param passwordEncoder 비밀번호를 암호화하는 함수
+	 * @return 변환된 UserDto.Create
+	 */
+	public UserDto.Create toCreateUserDto(UserDto.Create create, Function<String, String> passwordEncoder) {
+		String hashedPassword = passwordEncoder.apply(create.password());
+		return new UserDto.Create(
+			create.name(),
+			create.email(),
+			hashedPassword,
+			create.phoneNumber(),
+			create.role()
+		);
+	}
+}

--- a/auth-service/src/main/java/com/ticketing/authservice/infrastructure/client/UserFeignClient.java
+++ b/auth-service/src/main/java/com/ticketing/authservice/infrastructure/client/UserFeignClient.java
@@ -1,0 +1,36 @@
+package com.ticketing.authservice.infrastructure.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.ticketing.authservice.application.dto.UserDto;
+
+/**
+ * UserFeignClient는 user-service와 통신하여 사용자 정보를 처리하는 클라이언트 인터페이스입니다.
+ *
+ * 서비스 이름과 URL은 환경 변수에서 가져옵니다.
+ */
+@FeignClient(name = "${user-service.name}", url = "${user-service.url}")
+public interface UserFeignClient {
+
+	/**
+	 * user-service로 사용자 생성 요청을 처리하는 메서드입니다.
+	 *
+	 * @param create 생성할 사용자 정보가 담긴 DTO
+	 * @return 생성된 사용자 정보가 담긴 UserDto.Result 객체
+	 */
+	@PostMapping("/internal/users")
+	UserDto.Result createUser(@RequestBody UserDto.Create create);
+
+	/**
+	 * 이메일을 기반으로 사용자 정보를 조회하는 메서드입니다.
+	 *
+	 * @param email 조회할 사용자 이메일
+	 * @return 조회된 사용자 정보가 담긴 UserDto.Result 객체
+	 */
+	@GetMapping("/internal/users")
+	UserDto.Auth.Result readUserByEmail(@RequestParam("email") String email);
+}

--- a/auth-service/src/main/java/com/ticketing/authservice/infrastructure/client/UserFeignService.java
+++ b/auth-service/src/main/java/com/ticketing/authservice/infrastructure/client/UserFeignService.java
@@ -1,0 +1,37 @@
+package com.ticketing.authservice.infrastructure.client;
+
+import org.springframework.stereotype.Service;
+
+import com.ticketing.authservice.application.dto.UserDto;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * UserFeignService는 Feign Client를 통해 user-service와 통신하는 로직을 담당하는 서비스입니다.
+ */
+@Service
+@RequiredArgsConstructor
+public class UserFeignService {
+
+	private final UserFeignClient userFeignClient;
+
+	/**
+	 * user-service로 사용자 생성 요청을 보내는 메서드입니다.
+	 *
+	 * @param create 생성할 사용자 정보가 담긴 UserDto.Create
+	 * @return 생성된 사용자 정보가 담긴 UserDto.Result
+	 */
+	public UserDto.Result createUser(UserDto.Create create) {
+		return userFeignClient.createUser(create);
+	}
+
+	/**
+	 * user-service로부터 사용자 정보를 조회하는 메서드입니다.
+	 *
+	 * @param email 조회할 사용자 ID
+	 * @return 조회된 사용자 정보가 담긴 UserDto.Auth.Result
+	 */
+	public UserDto.Auth.Result readUserByEmail(String email) {
+		return userFeignClient.readUserByEmail(email);
+	}
+}

--- a/auth-service/src/main/java/com/ticketing/authservice/infrastructure/common/RoleType.java
+++ b/auth-service/src/main/java/com/ticketing/authservice/infrastructure/common/RoleType.java
@@ -1,0 +1,40 @@
+package com.ticketing.authservice.infrastructure.common;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum RoleType {//TODO: 공통모듈 적용시 통합
+
+	USER(Authority.USER),
+	MANAGER(Authority.MANAGER),
+	MASTER(Authority.MASTER);
+
+	private final String authority;
+
+	/**
+	 * roleCode에 따른 RoleType을 반환
+	 *
+	 * @param roleCode 전달 받은 권한(Role_권한)형식
+	 * @return RoleType
+	 */
+	public static RoleType fromRoleCode(String roleCode) {
+		for (RoleType role : RoleType.values()) {
+			if (role.authority.equalsIgnoreCase(roleCode)) {
+				return role;
+			}
+		}
+		throw new IllegalArgumentException("Invalid role code: " + roleCode);
+	}
+
+	public String getAuthority() {
+		return this.authority;
+	}
+
+	public static class Authority {
+		public static final String USER = "ROLE_USER";
+		public static final String MANAGER = "ROLE_MANAGER";
+		public static final String MASTER = "ROLE_MASTER";
+	}
+
+}
+

--- a/auth-service/src/main/java/com/ticketing/authservice/infrastructure/security/BCryptUtil.java
+++ b/auth-service/src/main/java/com/ticketing/authservice/infrastructure/security/BCryptUtil.java
@@ -1,0 +1,34 @@
+package com.ticketing.authservice.infrastructure.security;
+
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Component;
+
+/**
+ * BCryptUtil은 비밀번호를 해시화하고 검증하는 유틸리티 클래스입니다.
+ */
+@Component
+public class BCryptUtil {
+
+	private final BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+
+	/**
+	 * 비밀번호를 BCrypt 알고리즘으로 해시화하는 메서드입니다.
+	 *
+	 * @param password 원본 비밀번호
+	 * @return 해시화된 비밀번호
+	 */
+	public String hashPassword(String password) {
+		return passwordEncoder.encode(password);
+	}
+
+	/**
+	 * 원본 비밀번호와 해시화된 비밀번호가 일치하는지 확인하는 메서드입니다.
+	 *
+	 * @param rawPassword 원본 비밀번호
+	 * @param encodedPassword 해시화된 비밀번호
+	 * @return 비밀번호가 일치하면 true, 그렇지 않으면 false
+	 */
+	public boolean checkPassword(String rawPassword, String encodedPassword) {
+		return passwordEncoder.matches(rawPassword, encodedPassword);
+	}
+}

--- a/auth-service/src/main/java/com/ticketing/authservice/infrastructure/security/JwtUtil.java
+++ b/auth-service/src/main/java/com/ticketing/authservice/infrastructure/security/JwtUtil.java
@@ -1,0 +1,80 @@
+package com.ticketing.authservice.infrastructure.security;
+
+import java.util.Date;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+
+/**
+ * JwtUtil은 JWT 토큰을 생성하고 검증하는 유틸리티 클래스입니다.
+ */
+@Component
+public class JwtUtil {
+
+	// 환경 변수에서 시크릿 키와 만료 시간 값을 주입받습니다.
+	private final SecretKey secretKey;
+	private final long jwtExpirationMs;
+
+	// @Value 어노테이션을 통해 yml 파일에서 직접 SecretKey 및 만료 시간 설정
+	public JwtUtil(
+		@Value("${jwt.secret}") String secretKeyString,
+		@Value("${jwt.expiration}") long jwtExpirationMs) {
+		this.secretKey = Keys.hmacShaKeyFor(secretKeyString.getBytes());
+		this.jwtExpirationMs = jwtExpirationMs;
+	}
+
+	/**
+	 * 주어진 사용자 정보를 기반으로 JWT 토큰을 생성하는 메서드입니다.
+	 *
+	 * @param userId 사용자 ID
+	 * @param email 사용자 이메일
+	 * @param role 사용자 권한
+	 * @return 생성된 JWT 토큰
+	 */
+	public String createToken(Long userId, String email, String role) {
+		return Jwts.builder()
+			.setSubject(String.valueOf(userId))
+			.claim("email", email)
+			.claim("role", role)
+			.setIssuedAt(new Date())
+			.setExpiration(new Date(System.currentTimeMillis() + jwtExpirationMs)) // 설정된 만료 시간 사용
+			.signWith(secretKey, SignatureAlgorithm.HS256) // SecretKey와 알고리즘을 명시
+			.compact();
+	}
+
+	/**
+	 * JWT 토큰에서 클레임 정보를 추출하는 메서드입니다.
+	 *
+	 * @param token JWT 토큰
+	 * @return 토큰에서 추출한 클레임
+	 */
+	public Claims extractClaims(String token) {
+		return Jwts.parserBuilder() // parser() 대신 parserBuilder() 사용
+			.setSigningKey(secretKey) // SecretKey를 사용해 서명 검증
+			.build()
+			.parseClaimsJws(token)
+			.getBody();
+	}
+
+	/**
+	 * 주어진 JWT 토큰의 유효성을 검증하는 메서드입니다.
+	 *
+	 * @param token 검증할 JWT 토큰
+	 * @return 유효한 토큰이면 true, 그렇지 않으면 false
+	 */
+	public boolean isTokenValid(String token) {
+		try {
+			extractClaims(token);
+			return true;
+		} catch (Exception e) {
+			return false;
+		}
+	}
+}

--- a/auth-service/src/main/resources/application.properties
+++ b/auth-service/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=auth-service

--- a/auth-service/src/main/resources/application.yml
+++ b/auth-service/src/main/resources/application.yml
@@ -1,0 +1,22 @@
+server:
+  port: ${AUTH_PORT}  # Auth 서비스의 포트 설정
+
+jwt:
+  secret: ${JWT_SECRET_KEY}  # JWT 토큰 생성에 사용할 시크릿 키
+  expiration: ${JWT_EXPIRATION_TIME}  # JWT 만료 시간
+
+feign:
+  client:
+    config:
+      default:
+        connect-timeout: 5000  # 타임아웃 설정 (연결)
+        read-timeout: 5000     # 타임아웃 설정 (응답)
+
+# Feign Client를 통해 호출하는 user-service 설정
+user-service:
+  name: ${USER_SERVICE_NAME}  # internal 호출용 FeignClient에서 참조할 서비스 이름
+  url: ${USER_SERVICE_URL}  # internal 호출용 URL
+
+logging:
+  level:
+    com.ticketing.auth-service: DEBUG  # Auth 서비스 패키지에 대한 디버그 로깅

--- a/auth-service/src/test/resources/application.yml
+++ b/auth-service/src/test/resources/application.yml
@@ -1,0 +1,12 @@
+jwt:
+  secret: ${JWT_SECRET_KEY:X9e@w!S#l2P&xLm9QzK^rMtO!ZrYz8Vw0LzM8Vq1D&PtYnN7}  # JWT 토큰 생성에 사용할 시크릿 키
+  expiration: ${JWT_EXPIRATION_TIME:604800000} #7일
+
+# Feign Client를 통해 호출하는 user-service 설정
+user-service:
+  name: ${USER_SERVICE_NAME:user-service}  # internal 호출용 FeignClient에서 참조할 서비스 이름
+  url: ${USER_SERVICE_URL:http://localhost:19092}  # internal 호출용 URL
+
+logging:
+  level:
+    com.ticketing.auth-service: DEBUG  # Auth 서비스 패키지에 대한 디버그 로깅


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #23 

## 📌 PR 요약

인증 서비스의 기본 유틸리티 및 설정 추가

## 🔍 주요 변경 사항

- `UserDto` 추가: 사용자 정보 전송을 위한 DTO 정의
- `RoleType Enum` 추가: 사용자 권한 관리를 위한 Enum 정의
- `JwtUtil` 추가: JWT 토큰 생성 및 검증 유틸리티 클래스
- `BCryptUtil` 추가: 비밀번호 암호화 및 검증 유틸리티 클래스
- `UserFeignClient` 및 `UserFeignService` 추가: `user-service`와의 통신을 위한 Feign Client 정의
- `AuthDataMapper` 추가: DTO 변환을 위한 매퍼 클래스
- `build.gradle`에 JWT, BCrypt, Feign 관련 의존성 추가
- `application.yml`에 JWT 설정 및 Feign Client 설정 추가

## 🧪 테스트 방법

```bash
./gradlew test
```

## ✅ PR 체크리스트

- [x] 코드 컨벤션을 준수했나요?
- [x] 필요한 테스트를 추가하고 모든 테스트가 통과하나요?
- [ ] 관련 문서를 업데이트했나요? (필요한 경우)

## 👀 리뷰어 체크 포인트

- JWT 토큰은 id, email, role 이 포함된 상태입니다
- email은 유니크 하다는 가정으로 진행되었습니다

## 💬 기타 코멘트

- 이 PR은 추후 모듈 분리를 고려하여 작성되었습니다.
- Slack을 통해 제공될 auth-local.env 파일을 반드시 환경 변수로 등록해야 합니다.

