### PR TITLE
✨ 인증 서비스 API 구현

### DIFF
--- a/auth-service/src/main/java/com/ticketing/authservice/application/service/AuthService.java
+++ b/auth-service/src/main/java/com/ticketing/authservice/application/service/AuthService.java
@@ -1,0 +1,60 @@
+package com.ticketing.authservice.application.service;
+
+import static com.ticketing.authservice.infrastructure.common.CustomException.*;
+
+import org.springframework.stereotype.Service;
+
+import com.ticketing.authservice.application.dto.UserDto;
+import com.ticketing.authservice.application.mapper.AuthDataMapper;
+import com.ticketing.authservice.infrastructure.client.UserFeignService;
+import com.ticketing.authservice.infrastructure.security.BCryptUtil;
+import com.ticketing.authservice.infrastructure.security.JwtUtil;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * AuthService는 회원가입 및 로그인과 관련된 비즈니스 로직을 처리하는 서비스입니다.
+ */
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+	private final BCryptUtil bCryptUtil;
+	private final AuthDataMapper authDataMapper;
+	private final UserFeignService userFeignService;
+	private final JwtUtil jwtUtil;
+
+	/**
+	 * 회원가입 로직을 처리하는 메서드입니다.
+	 *
+	 * @param create 회원가입 요청 데이터를 담은 DTO
+	 * @return 회원가입 결과를 담은 DTO
+	 */
+	public UserDto.Result signup(UserDto.Create create) {
+		// UserDto.Create 생성 및 비밀번호 암호화 (암호화 로직 전달)
+		UserDto.Create createUserDto = authDataMapper.toCreateUserDto(create, bCryptUtil::hashPassword);
+
+		// Feign Client를 통해 user-service에 사용자 생성 요청
+		return userFeignService.createUser(createUserDto);
+	}
+
+	/**
+	 * 로그인 로직을 처리하는 메서드입니다.
+	 *
+	 * @param login 로그인 요청 데이터를 담은 DTO
+	 * @return 로그인 성공 시 JWT 토큰
+	 */
+	public String login(UserDto.Auth.Login login) {
+		// Feign Client를 통해 user-service에서 사용자 정보 조회
+		UserDto.Auth.Result user = userFeignService.readUserByEmail(login.email());
+
+		// 비밀번호 확인 (BCryptUtil 사용)
+		if (!bCryptUtil.checkPassword(login.password(), user.password())) {
+			// 비밀번호 불일치 시 PasswordMismatchException 예외를 던집니다
+			throw new PasswordMismatchException(user.id());
+		}
+
+		// JWT 토큰 생성
+		return jwtUtil.createToken(user.id(), user.email(), user.role().getAuthority());
+	}
+}

--- a/auth-service/src/main/java/com/ticketing/authservice/infrastructure/common/CustomException.java
+++ b/auth-service/src/main/java/com/ticketing/authservice/infrastructure/common/CustomException.java
@@ -1,0 +1,83 @@
+package com.ticketing.authservice.infrastructure.common;
+
+import java.util.UUID;
+
+import com.ticketing.authservice.infrastructure.common.codes.ErrorCode;
+
+import lombok.Getter;
+
+/**
+ * [공통 예외 클래스] API에서 발생하는 모든 예외를 관리하는 클래스.
+ * 이 클래스는 비즈니스 로직 내에서 발생하는 모든 예외를 처리하며,
+ * 각 예외는 {@link ErrorCode}를 통해 구분된다.
+ *
+ * <p>이 클래스는 기본적으로 {@link RuntimeException}을 확장하여
+ * 런타임 예외로 처리되며, 추가적으로 커스텀 메시지를 포함할 수 있다.
+ */
+@Getter
+public class CustomException extends RuntimeException {
+	private final ErrorCode errorCode;
+	private final String customMessage;
+	private final String errorId;
+
+	/**
+	 * 기본 생성자. 에러 ID는 접두사를 붙여 쉽게 추적할 수 있게 구성.
+	 *
+	 * @param errorCode 에러 코드 (ErrorCode)
+	 */
+	public CustomException(ErrorCode errorCode) {
+		super(errorCode.getMessage());
+		this.errorCode = errorCode;
+		this.customMessage = null;
+		this.errorId = generateErrorId(); // 에러 ID 생성
+	}
+
+	/**
+	 * 커스텀 메시지와 함께 에러를 생성하는 생성자.
+	 *
+	 * @param errorCode     에러 코드 (ErrorCode)
+	 * @param customMessage 커스텀 메시지 (String)
+	 */
+	public CustomException(ErrorCode errorCode, String customMessage) {
+		super(customMessage != null ? customMessage : errorCode.getMessage());
+		this.errorCode = errorCode;
+		this.customMessage = customMessage;
+		this.errorId = generateErrorId(); // 에러 ID 생성
+	}
+
+	/**
+	 * 에러 ID 생성 메서드. 접두사와 함께 짧은 UUID를 생성.
+	 *
+	 * @return 접두사가 포함된 에러 ID
+	 */
+	private String generateErrorId() {
+		return "ERR-" + UUID.randomUUID().toString().substring(0, 8); // UUID 앞 8자리만 사용
+	}
+
+	/**
+	 * 비밀번호 불일치 예외를 처리하는 내부 클래스.
+	 */
+	@Getter
+	public static class PasswordMismatchException extends CustomException {
+
+		/**
+		 * 비밀번호 불일치 시 발생하는 예외.
+		 *
+		 * @param userId    사용자 ID
+		 */
+		public PasswordMismatchException(Long userId) {
+			super(ErrorCode.PASSWORD_MISMATCH,
+				String.format("Password mismatch for User ID (%d)", userId));
+		}
+
+		/**
+		 * 비밀번호 불일치 시 발생하는 예외 (UUID 기반).
+		 *
+		 * @param userId    사용자 UUID
+		 */
+		public PasswordMismatchException(UUID userId) {
+			super(ErrorCode.PASSWORD_MISMATCH,
+				String.format("Password mismatch for User UUID (%s)", userId.toString()));
+		}
+	}
+}

--- a/auth-service/src/main/java/com/ticketing/authservice/infrastructure/common/codes/ErrorCode.java
+++ b/auth-service/src/main/java/com/ticketing/authservice/infrastructure/common/codes/ErrorCode.java
@@ -1,0 +1,52 @@
+package com.ticketing.authservice.infrastructure.common.codes;
+
+import java.io.Serializable;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+
+/**
+ * [공통 코드] API 통신에 대한 '에러 코드'를 Enum 형태로 관리를 한다.
+ * Global Error CodeList : 전역으로 발생하는 에러코드를 관리한다.
+ * Custom Error CodeList : 업무 페이지에서 발생하는 에러코드를 관리한다
+ * Error Code Constructor : 에러코드를 직접적으로 사용하기 위한 생성자를 구성한다.
+ */
+@Getter
+public enum ErrorCode implements ResponseCode, Serializable { //TODO: 공통 모듈 적용시 통합
+
+	/**
+	 * ******************************* Global Error CodeList ***************************************
+	 * HTTP Status Code
+	 * 400 : Bad Request
+	 * 401 : Unauthorized
+	 * 403 : Forbidden
+	 * 404 : Not Found
+	 * 500 : Internal Server Error
+	 * *********************************************************************************************
+	 */
+
+	// 비밀번호 불일치
+	PASSWORD_MISMATCH(HttpStatus.UNAUTHORIZED, "A001", "Invalid password"),
+
+	; // End
+
+	/**
+	 * ******************************* Error Code Constructor ***************************************
+	 */
+	// 에러 코드의 '코드 상태'를 반환한다.
+	private final HttpStatus status;
+
+	// 에러 코드의 '코드간 구분 값'을 반환한다.
+	private final String divisionCode;
+
+	// 에러 코드의 '코드 메시지'를 반환한다.
+	private final String message;
+
+	// 생성자 구성
+	ErrorCode(final HttpStatus status, final String divisionCode, final String message) {
+		this.status = status;
+		this.divisionCode = divisionCode;
+		this.message = message;
+	}
+}

--- a/auth-service/src/main/java/com/ticketing/authservice/infrastructure/common/codes/ResponseCode.java
+++ b/auth-service/src/main/java/com/ticketing/authservice/infrastructure/common/codes/ResponseCode.java
@@ -1,0 +1,11 @@
+package com.ticketing.authservice.infrastructure.common.codes;
+
+import org.springframework.http.HttpStatus;
+
+public interface ResponseCode { //TODO: 공통 모듈 적용시 통합
+	HttpStatus getStatus();
+
+	String getMessage();
+
+	String getDivisionCode();
+}

--- a/auth-service/src/main/java/com/ticketing/authservice/presentation/controller/AuthController.java
+++ b/auth-service/src/main/java/com/ticketing/authservice/presentation/controller/AuthController.java
@@ -1,0 +1,46 @@
+package com.ticketing.authservice.presentation.controller;
+
+import static org.springframework.http.HttpStatus.*;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ticketing.authservice.application.dto.UserDto;
+import com.ticketing.authservice.application.service.AuthService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("api/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+	private final AuthService authService;
+
+	/**
+	 * 회원가입 엔드포인트입니다.
+	 *
+	 * @param create 회원가입 요청 데이터를 담은 DTO
+	 * @return 회원가입 결과를 담은 DTO
+	 */
+	@PostMapping("/signup")
+	public ResponseEntity<UserDto.Result> signup(@RequestBody UserDto.Create create) {
+		UserDto.Result result = authService.signup(create);
+		return new ResponseEntity<>(result, CREATED);  // 201 Created
+	}
+
+	/**
+	 * 로그인 엔드포인트입니다.
+	 *
+	 * @param login 로그인 요청 데이터를 담은 DTO
+	 * @return JWT 토큰을 담은 응답
+	 */
+	@PostMapping("/login")
+	public ResponseEntity<String> login(@RequestBody UserDto.Auth.Login login) {
+		String token = authService.login(login);
+		return new ResponseEntity<>(token, OK);  // 200 OK
+	}
+}

--- a/auth-service/src/test/java/com/ticketing/authservice/application/service/AuthServiceTest.java
+++ b/auth-service/src/test/java/com/ticketing/authservice/application/service/AuthServiceTest.java
@@ -1,0 +1,96 @@
+package com.ticketing.authservice.application.service;
+
+import static com.ticketing.authservice.infrastructure.helper.ArbitraryUserFactory.*;
+import static com.ticketing.authservice.infrastructure.helper.util.ArbitraryField.*;
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import com.ticketing.authservice.application.dto.UserDto;
+import com.ticketing.authservice.application.mapper.AuthDataMapper;
+import com.ticketing.authservice.infrastructure.client.UserFeignService;
+import com.ticketing.authservice.infrastructure.common.CustomException.PasswordMismatchException;
+import com.ticketing.authservice.infrastructure.security.BCryptUtil;
+import com.ticketing.authservice.infrastructure.security.JwtUtil;
+
+/**
+ * {@code AuthServiceTest}는 {@code AuthService}의 회원 인증과 관련된
+ * 비즈니스 로직을 테스트하는 클래스입니다.
+ */
+class AuthServiceTest {
+
+	@Mock
+	private UserFeignService userFeignService; // FeignClient 모킹
+
+	private BCryptUtil bCryptUtil; // 비밀번호 암호화 유틸리티 인스턴스
+	private JwtUtil jwtUtil; // JWT 유틸리티 인스턴스
+	private AuthDataMapper authDataMapper;
+
+	@InjectMocks
+	private AuthService authService; // AuthService에 의존성 주입
+
+	/**
+	 * 테스트 시작 전에 Mockito의 목 객체를 초기화합니다.
+	 */
+	@BeforeEach
+	void setUp() {
+		openMocks(this);
+		this.bCryptUtil = new BCryptUtil(); // BCryptUtil 인스턴스 생성
+		this.jwtUtil = new JwtUtil(JWT_SECRET, JWT_EXPIRATION); // JwtUtil 인스턴스 생성
+		authService = new AuthService(bCryptUtil, authDataMapper, userFeignService, jwtUtil); // AuthService 인스턴스 생성
+	}
+
+	/**
+	 * 유효한 사용자 인증 정보로 로그인할 때 JWT 토큰을 반환하는지 테스트합니다.
+	 *
+	 * @throws Exception 유효한 자격 증명이 있는 경우 발생할 수 있는 예외
+	 */
+	@Test
+	@DisplayName("유효한 사용자 자격 정보로 로그인시 JWT 토큰 반환")
+	void login_userWithValidCredentials_returnsJwtToken() throws Exception {
+		// Given: 로그인 요청 DTO와 User 정보 생성
+		UserDto.Auth.Login loginDto = createLoginDto();
+		UserDto.Auth.Result fetchedUser = createAuthResult()
+			.withPassword(bCryptUtil.hashPassword(PASSWORD));
+
+		// Mock: FeignClient 호출 및 비밀번호 검증
+		when(userFeignService.readUserByEmail(loginDto.email()))
+			.thenReturn(fetchedUser);
+
+		// When: 로그인 처리
+		String token = authService.login(loginDto);
+
+		// Then: JWT 토큰이 성공적으로 생성되었는지 확인
+		assertThat(token, notNullValue());
+		assertThat(jwtUtil.isTokenValid(token), is(true)); // 토큰 유효성 확인
+	}
+
+	/**
+	 * 잘못된 비밀번호로 로그인 시도 시 {@code PasswordMismatchException}이
+	 * 발생하는지 테스트합니다.
+	 */
+	@Test
+	@DisplayName("로그인 요청시 비밀번호 불일치로 예외 발생")
+	void login_userWithInvalidPassword_throwsPasswordMismatchException() {
+		// Given: 로그인 요청 DTO와 잘못된 비밀번호 정보
+		UserDto.Auth.Login loginDto = createLoginDto();
+		UserDto.Auth.Result fetchedUser = createAuthResult()
+			.withPassword(bCryptUtil.hashPassword("inVa1!rdPassw0rd"));
+
+		// Mock: FeignClient 호출 및 잘못된 비밀번호 검증
+		when(userFeignService.readUserByEmail(loginDto.email()))
+			.thenReturn(fetchedUser);
+
+		// When & Then: 비밀번호 불일치로 예외 발생
+		assertThrows(PasswordMismatchException.class, () -> authService.login(loginDto));
+		verify(userFeignService, times(1)).readUserByEmail(loginDto.email());
+	}
+}

--- a/auth-service/src/test/java/com/ticketing/authservice/infrastructure/helper/ArbitraryUserFactory.java
+++ b/auth-service/src/test/java/com/ticketing/authservice/infrastructure/helper/ArbitraryUserFactory.java
@@ -1,0 +1,26 @@
+package com.ticketing.authservice.infrastructure.helper;
+
+import static com.ticketing.authservice.infrastructure.common.RoleType.*;
+import static com.ticketing.authservice.infrastructure.helper.util.ArbitraryField.*;
+
+import com.ticketing.authservice.application.dto.UserDto;
+
+public class ArbitraryUserFactory {
+
+	public static UserDto.Auth.Login createLoginDto() {
+		return UserDto.Auth.Login.builder()
+			.email(USER_EMAIL)
+			.password(PASSWORD)
+			.build();
+	}
+
+	public static UserDto.Auth.Result createAuthResult() {
+		return UserDto.Auth.Result.builder()
+			.id(USER_ID)
+			.name(USER_NAME)
+			.email(USER_EMAIL)
+			.password(HASHED_PASSWORD)
+			.role(USER)
+			.build();
+	}
+}

--- a/auth-service/src/test/java/com/ticketing/authservice/infrastructure/helper/util/ArbitraryField.java
+++ b/auth-service/src/test/java/com/ticketing/authservice/infrastructure/helper/util/ArbitraryField.java
@@ -1,0 +1,34 @@
+package com.ticketing.authservice.infrastructure.helper.util;
+
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import com.ticketing.authservice.infrastructure.common.RoleType;
+
+/**
+ * 테스트에 사용될 임의의 필드 값을 정의하는 클래스입니다.
+ * 이 클래스는 주로 테스트 시 반복적으로 사용되는 상수 값을 관리합니다.
+ */
+public class ArbitraryField {
+
+	/** 테스트용 사용자 ID */
+	public static final Long USER_ID = 1L;
+	/** 테스트용 사용자 이름 */
+	public static final String USER_NAME = "Test User";
+	/** 테스트용 사용자 이메일 */
+	public static final String USER_EMAIL = "testuser@example.com";
+	/** 테스트용 사용자 비밀번호 (평문) */
+	public static final String PASSWORD = "!P@ssW0rd";
+	/** 테스트용 사용자 전화번호 */
+	public static final String PHONE_NUMBER = "010-1234-5678";
+	/** 테스트용 JWT 토큰 */
+	public static final String JWT_TOKEN = "sample.jwt.token";
+	/** 테스트용 사용자 권한 */
+	public static final RoleType USER_ROLE = RoleType.USER;
+	/** JWT 테스트용 시크릿 키 (최소 32바이트) */
+	public static final String JWT_SECRET = "myJwtSecretKeyForTesting1234567890!";
+	/** JWT 테스트용 만료 시간 (밀리초) */
+	public static final long JWT_EXPIRATION = 3600000L; // 1시간
+	private static final BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+	/** 테스트용 해시된 비밀번호 */
+	public static final String HASHED_PASSWORD = passwordEncoder.encode(PASSWORD);
+}

--- a/auth-service/src/test/java/com/ticketing/authservice/infrastructure/security/JwtUtilTest.java
+++ b/auth-service/src/test/java/com/ticketing/authservice/infrastructure/security/JwtUtilTest.java
@@ -1,0 +1,72 @@
+package com.ticketing.authservice.infrastructure.security;
+
+import static com.ticketing.authservice.infrastructure.helper.util.ArbitraryField.*;
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+
+import java.util.Date;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+
+/**
+ * JwtUtilTest는 JwtUtil 클래스의 토큰 생성 및 검증 기능을 테스트합니다.
+ */
+class JwtUtilTest {
+
+	private JwtUtil jwtUtil;
+
+	@BeforeEach
+	void setUp() {
+		jwtUtil = new JwtUtil(JWT_SECRET, JWT_EXPIRATION);
+	}
+
+	/**
+	 * 유효한 JWT 토큰에서 클레임이 올바르게 추출되는지 테스트합니다.
+	 */
+	@Test
+	@DisplayName("유효한 토큰 생성 시 클레임이 정상적으로 추출")
+	void validToken_extractingClaims_claimsSuccessfullyExtracted() {
+		// Given: 임의의 유효한 JWT 토큰 생성
+		String validJwtToken = jwtUtil.createToken(USER_ID, USER_EMAIL, USER_ROLE.getAuthority());
+
+		// When: 토큰에서 클레임 추출
+		Claims extractedClaims = jwtUtil.extractClaims(validJwtToken);
+
+		// Then: Hamcrest를 사용하여 토큰에서 추출된 정보와 유효성을 확인
+		assertThat(extractedClaims.getSubject(), equalTo(USER_ID.toString()));
+		assertThat(extractedClaims.get("email"), equalTo(USER_EMAIL));
+		assertThat(extractedClaims.get("role"), equalTo(USER_ROLE.getAuthority()));
+		assertThat(jwtUtil.isTokenValid(validJwtToken), is(true)); // 유효한 토큰인지 추가 검증
+	}
+
+	/**
+	 * 만료된 JWT 토큰의 유효성 검증이 실패하는지 테스트합니다.
+	 */
+	@Test
+	@DisplayName("만료된 토큰의 유효성 검증 시 실패")
+	void expiredToken_validatingToken_validationFails() {
+		// Given: 만료된 JWT 토큰 생성
+		Date expiredDate = new Date(System.currentTimeMillis() - 1000); // 1초 전 만료
+		String expiredToken = Jwts.builder()
+			.setSubject(USER_ID.toString())
+			.claim("email", USER_EMAIL)
+			.claim("role", USER_ROLE.getAuthority())
+			.setIssuedAt(new Date(System.currentTimeMillis() - 2000)) // 2초 전 발행
+			.setExpiration(expiredDate)
+			.signWith(Keys.hmacShaKeyFor(JWT_SECRET.getBytes()), SignatureAlgorithm.HS256)
+			.compact();
+
+		// When: 토큰의 유효성 검증
+		boolean isValid = jwtUtil.isTokenValid(expiredToken);
+
+		// Then: 만료된 토큰이 유효하지 않은지 Hamcrest로 확인
+		assertThat(isValid, is(false));
+	}
+}


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #29 

## 📌 PR 요약

인증 서비스 비즈니스 로직 구현

## 🔍 주요 변경 사항

- 회원가입과 로그인 기능을 처리하는 비즈니스 로직 추가
  - 비밀번호 암호화 및 검증 로직을 포함한 인증 흐름 구성
  - `JwtUtil`을 통한 JWT 토큰 생성 및 검증
  - 비밀번호 불일치에 대한 예외 처리 로직 추가 (`PasswordMismatchException`)
- `AuthService`의 유닛 테스트 및 `JwtUtil` 테스트 케이스 작성

## 🧪 테스트 방법

<!-- 이 변경 사항을 어떻게 테스트할 수 있는지 간단히 설명해주세요 -->
```bash
./gradlew test
```

## ✅ PR 체크리스트

- [x] 코드 컨벤션을 준수했나요?
- [x] 필요한 테스트를 추가하고 모든 테스트가 통과하나요?
- [] 관련 문서를 업데이트했나요? (필요한 경우)

## 👀 리뷰어 체크 포인트

- 공통 모듈 관련 작업은 추후에 별도로 진행할 예정입니다.
- 테스트 코드는 성공적인 feign 통신을 가정하고 작성되었습니다.

## 💬 기타 코멘트

- `ArbitraryField`는 추후 공통 모듈로 통합될 예정입니다.