### PR TITLE
✨ 카카오페이 연동

### DIFF
--- a/payment-service/src/main/java/com/ipho4ticket/paymentservice/application/dto/ApproveResponse.java
+++ b/payment-service/src/main/java/com/ipho4ticket/paymentservice/application/dto/ApproveResponse.java
@@ -1,0 +1,24 @@
+package com.ipho4ticket.paymentservice.application.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+public class ApproveResponse {
+
+    private String aid;                 // 요청 고유 번호
+    private String tid;                 // 결제 고유 번호
+    private String cid;                 // 가맹점 코드
+    private String partner_order_id;    // 가맹점 주문번호
+    private String partner_user_id;     // 가맹점 회원 id
+    private String payment_method_type; // 결제 수단, CARD 또는 MONEY 중 하나
+    private String item_name;           // 상품 이름
+    private String item_code;           // 상품 코드
+    private int quantity;               // 상품 수량
+    private String created_at;          // 결제 준비 요청 시각
+    private String approved_at;         // 결제 승인 시각
+    private String payload;             // 결제 승인 요청에 대해 저장한 값, 요청 시 전달된 내용
+}

--- a/payment-service/src/main/java/com/ipho4ticket/paymentservice/application/dto/ReadyResponse.java
+++ b/payment-service/src/main/java/com/ipho4ticket/paymentservice/application/dto/ReadyResponse.java
@@ -1,0 +1,14 @@
+package com.ipho4ticket.paymentservice.application.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+public class ReadyResponse {
+
+    private String tid;                  // 결제 고유번호
+    private String next_redirect_pc_url; // 카카오톡으로 결제 요청 메시지(TMS)를 보내기 위한 사용자 정보 입력화면 Redirect URL (카카오 측 제공)
+}

--- a/payment-service/src/main/java/com/ipho4ticket/paymentservice/application/factory/PaymentProcessorFactory.java
+++ b/payment-service/src/main/java/com/ipho4ticket/paymentservice/application/factory/PaymentProcessorFactory.java
@@ -1,0 +1,26 @@
+package com.ipho4ticket.paymentservice.application.factory;
+
+import com.ipho4ticket.paymentservice.domain.model.PaymentMethod;
+import com.ipho4ticket.paymentservice.domain.service.PaymentProcessor;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PaymentProcessorFactory {
+    private final Map<String, PaymentProcessor> processorMap;
+
+    @Autowired
+    public PaymentProcessorFactory(List<PaymentProcessor> processors) {
+        // 결제 모듈 이름과 구현체를 매핑
+        this.processorMap = processors.stream()
+            .collect(Collectors.toMap(processor -> processor.getClass().getSimpleName(), processor -> processor));
+    }
+
+    public PaymentProcessor getPaymentProcessor(PaymentMethod paymentMethod) {
+        // Enum의 processorName 값을 사용하여 적절한 결제 모듈을 반환
+        return processorMap.get(paymentMethod.getProcessorName());
+    }
+}

--- a/payment-service/src/main/java/com/ipho4ticket/paymentservice/domain/model/Payment.java
+++ b/payment-service/src/main/java/com/ipho4ticket/paymentservice/domain/model/Payment.java
@@ -33,6 +33,9 @@ public class Payment {
     @Column(name= "ticket_id", nullable = false)
     private UUID ticketId; // 티켓 ID (외부 테이블 ticket과 연관)
 
+    @Column(name = "tid")
+    private String tid;
+
     @Column(name = "amount", precision = 10, scale = 2, nullable = false)
     private BigDecimal amount; // 결제 금액
 
@@ -59,5 +62,9 @@ public class Payment {
 
     public void updateStatus(PaymentStatus paymentStatus) {
         this.status = paymentStatus;
+    }
+
+    public void setTid(String tid) {
+        this.tid = tid;
     }
 }

--- a/payment-service/src/main/java/com/ipho4ticket/paymentservice/domain/model/PaymentMethod.java
+++ b/payment-service/src/main/java/com/ipho4ticket/paymentservice/domain/model/PaymentMethod.java
@@ -1,5 +1,12 @@
 package com.ipho4ticket.paymentservice.domain.model;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public enum PaymentMethod {
-    KAKAOPAY
+    KAKAO_PAY("KakaoPayService");
+
+    private final String processorName;
 }

--- a/payment-service/src/main/java/com/ipho4ticket/paymentservice/domain/model/PaymentStatus.java
+++ b/payment-service/src/main/java/com/ipho4ticket/paymentservice/domain/model/PaymentStatus.java
@@ -4,5 +4,6 @@ public enum PaymentStatus {
     OPENED,
     PENDING,
     COMPLETED,
+    FAILED,
     CANCELED
 }

--- a/payment-service/src/main/java/com/ipho4ticket/paymentservice/domain/service/PaymentDomainService.java
+++ b/payment-service/src/main/java/com/ipho4ticket/paymentservice/domain/service/PaymentDomainService.java
@@ -1,8 +1,0 @@
-package com.ipho4ticket.paymentservice.domain.service;
-
-import org.springframework.stereotype.Service;
-
-@Service
-public class PaymentDomainService {
-
-}

--- a/payment-service/src/main/java/com/ipho4ticket/paymentservice/domain/service/PaymentProcessor.java
+++ b/payment-service/src/main/java/com/ipho4ticket/paymentservice/domain/service/PaymentProcessor.java
@@ -1,0 +1,12 @@
+package com.ipho4ticket.paymentservice.domain.service;
+
+import com.ipho4ticket.paymentservice.application.dto.ApproveResponse;
+import com.ipho4ticket.paymentservice.application.dto.ReadyResponse;
+import java.math.BigDecimal;
+import java.util.UUID;
+
+public interface PaymentProcessor {
+    ReadyResponse payReady(String itemName, BigDecimal totalAmount, UUID ticket_id, UUID payment_id);
+    ApproveResponse payApprove(String tid, String pgToken);
+}
+

--- a/payment-service/src/main/java/com/ipho4ticket/paymentservice/infrastructure/external/KakaoPayService.java
+++ b/payment-service/src/main/java/com/ipho4ticket/paymentservice/infrastructure/external/KakaoPayService.java
@@ -1,0 +1,76 @@
+package com.ipho4ticket.paymentservice.infrastructure.external;
+
+import com.ipho4ticket.paymentservice.application.dto.ApproveResponse;
+import com.ipho4ticket.paymentservice.application.dto.ReadyResponse;
+import com.ipho4ticket.paymentservice.domain.service.PaymentProcessor;
+import java.math.BigDecimal;
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+public class KakaoPayService implements PaymentProcessor {
+
+    @Value("${kakao.pay.secret-key}")
+    private String kakaoPaySecretKey;
+
+    // 카카오페이 결제 준비
+    @Override
+    public ReadyResponse payReady(String itemName, BigDecimal totalAmount, UUID ticket_id, UUID payment_id) {
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("cid", "TC0ONETIME");                                    // 가맹점 코드
+        parameters.put("partner_order_id", "1234567890");          // 주문번호
+        parameters.put("partner_user_id", "userId");                            // 회원 아이디
+        parameters.put("item_name", itemName);                                  // 상품명
+        parameters.put("quantity", "1");                                        // 상품 수량
+        parameters.put("total_amount", String.valueOf(totalAmount));            // 총 금액
+        parameters.put("tax_free_amount", "0");                                 // 비과세 금액
+        parameters.put("approval_url", "http://localhost:8080/api/v1/payments/approve?payment_id=" + payment_id); // 성공 시 URL
+        parameters.put("cancel_url", "http://localhost:8080/order/pay/cancel");      // 취소 시 URL
+        parameters.put("fail_url", "http://localhost:8080/order/pay/fail");          // 실패 시 URL
+
+        HttpEntity<Map<String, String>> requestEntity = new HttpEntity<>(parameters, getHeaders());
+
+        RestTemplate template = new RestTemplate();
+        String url = "https://open-api.kakaopay.com/online/v1/payment/ready";
+        ResponseEntity<ReadyResponse> responseEntity = template.postForEntity(url, requestEntity, ReadyResponse.class);
+
+        return responseEntity.getBody();
+    }
+
+    // 카카오페이 결제 승인
+    @Override
+    public ApproveResponse payApprove(String tid, String pgToken) {
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("cid", "TC0ONETIME");
+        parameters.put("tid", tid);
+        parameters.put("partner_order_id", "1234567890");
+        parameters.put("partner_user_id", "userId");
+        parameters.put("pg_token", pgToken);
+
+        HttpEntity<Map<String, String>> requestEntity = new HttpEntity<>(parameters, getHeaders());
+
+        RestTemplate template = new RestTemplate();
+        String url = "https://open-api.kakaopay.com/online/v1/payment/approve";
+        ApproveResponse approveResponse = template.postForObject(url, requestEntity, ApproveResponse.class);
+
+        return approveResponse;
+    }
+
+    // 카카오페이 API 호출 시 필요한 헤더 생성
+    private HttpHeaders getHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "SECRET_KEY " + kakaoPaySecretKey); // 발급받은 Secret Key 입력
+        headers.set("Content-type", "application/json");
+
+        return headers;
+    }
+}
+

--- a/payment-service/src/main/resources/application.yml
+++ b/payment-service/src/main/resources/application.yml
@@ -32,3 +32,7 @@ storage:
       pool-name: db-payment-pool
       data-source-properties:
         rewriteBatchedStatements: true
+
+kakao:
+  pay:
+    secret-key: ${KAKAO_PAY_SECRET_KEY}


### PR DESCRIPTION
## 🔗 관련 이슈

<!-- 관련 이슈가 있다면 여기에 링크해주세요. 예: Closes #123, Related to #456 -->
Closes #42 
## 📌 PR 요약

<!-- 이 PR의 목적과 주요 변경 사항을 간단히 설명해주세요 -->

카카오페이 결제 모듈 추가

## 🔍 주요 변경 사항

<!-- bullet point로 주요 변경 사항을 나열해주세요 -->
- 카카오페이 결제 모듈 추가

## 🧪 테스트 방법

<!-- 이 변경 사항을 어떻게 테스트할 수 있는지 간단히 설명해주세요 -->
```bash
./gradlew test
```
## ✅ PR 체크리스트

- [x] 코드 컨벤션을 준수했나요?
- [x] 필요한 테스트를 추가하고 모든 테스트가 통과하나요?
- [ ] 관련 문서를 업데이트했나요? (필요한 경우)

## 👀 리뷰어 체크 포인트

<!-- 리뷰어가 특별히 확인해야 할 부분이 있다면 언급해주세요 -->

## 💬 기타 코멘트

<!-- 추가로 공유할 내용이 있다면 여기에 적어주세요 -->

1. 현재 수정해야 할 내용이 많이 있습니다.
- 성공의 경우에만 작성되어 있습니다. 추후 실패, 취소의 경우도 작성될 예정입니다.
- 다이렉트 localhost를 사용중인 부분도 환경설정으로 변경될 예정입니다.

2. 결제 모듈을 동기 방식으로 진행하기로 한 점
- 카카오페이 결제 모듈이 지원하는 방식이 기본적으로 리다이렉팅을 기본으로 하여 비동기 방식처럼 구성되었습니다.
- 따라서 2가지 선택지가 있습니다.
- (1) : Jmeter테스트가 어려워진 가운데 카카오페이 서버를 대신할 간단한 서버를 만들어서 통신하여 기존 카카오페이 결제의 내용을 대신 만든 서버에 보내 저장하고 응답을 보내는 방식으로 테스트
- (2) : 동기방식으로 처리 가능한 결제모듈을 추가로 탑재(이 부분 알아보고 있습니다.)

3. Ticket과의 통신에서의 변경점 필요
- 카카오페이 결제 시에 상품명을 입력이 필수 (현재는 임시값으로 조정)
- 따라서  1. ticketId와 userId를 통해 티켓 유효성 검사 시에 반환값에 상품명 (ex) 이벤트명 + 좌석 )과 같은 형식으로 상품명을 반환받아야 할거같습니다.

4. 카카오페이 결제 과정입니다.

- 결제 요청 보내기 (요청 시 redirect_url 반환)
- 프론트가 있을 경우 바로 리다이랙트가 가능하지만 postman에서 확인하기 힘들어 url을 반환하는 형식으로 변경했습니다.
![image](https://github.com/user-attachments/assets/6902b5a9-8113-450c-bbc3-b9cb94df3a61)

- 해당 url에 접근 시 아래 사진이 나타남
![image](https://github.com/user-attachments/assets/e787bf23-9777-4ba6-aa02-04df84ed1529)

- 모바일 카카오톡 qr 스캔을 통해 결제
- 결제 창 진입 시 모바일 사진
![Screenshot_20241007_144752_KakaoTalk](https://github.com/user-attachments/assets/636d80e2-1095-42fb-adac-cfcfa27e2c4e)

- 결제 창 진입 시 pc 사진
![image](https://github.com/user-attachments/assets/b955d299-ee06-4c3d-b527-f371c1c6d067)

- 결제 성공 화면
![image](https://github.com/user-attachments/assets/8c38c613-d677-45e5-a7b5-a56b61a7b933)



