### PR TITLE
✨ 게이트웨이 기본 서비스 구현

### DIFF
--- a/gateway-service/src/main/java/com/ticketing/gatewayservice/application/filter/AuthTokenFilter.java
+++ b/gateway-service/src/main/java/com/ticketing/gatewayservice/application/filter/AuthTokenFilter.java
@@ -1,0 +1,92 @@
+package com.ticketing.gatewayservice.application.filter;
+
+import static com.ticketing.gatewayservice.infrastructure.handler.AuthTokenResponseHandler.*;
+import static com.ticketing.gatewayservice.infrastructure.util.CacheUtils.*;
+import static com.ticketing.gatewayservice.infrastructure.util.TokenUtils.*;
+import static org.springframework.http.HttpHeaders.*;
+
+import java.util.Map;
+
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+
+import com.ticketing.gatewayservice.infrastructure.cache.CacheService;
+import com.ticketing.gatewayservice.infrastructure.feign.AuthWebClient;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Mono;
+
+/**
+ * JWT 토큰을 검증하고 필터 체인을 처리하는 필터입니다.
+ * 캐시에서 먼저 토큰을 확인하고, 없는 경우 Auth 서버에 요청하여 검증합니다.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class AuthTokenFilter implements GlobalFilter {
+
+	private final AuthWebClient authWebClient;
+	private final CacheService cacheService;
+
+	/**
+	 * 클라이언트 요청에서 JWT 토큰을 추출하고 이를 검증합니다.
+	 * 캐시에 토큰 정보가 있을 경우 캐시된 데이터를 사용하고, 없을 경우 Auth 서버에 토큰 검증을 요청합니다.
+	 *
+	 * @param exchange 서버 교환 객체 (요청 및 응답 정보를 포함)
+	 * @param chain 필터 체인
+	 * @return 필터 체인 결과
+	 */
+	@Override
+	public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+		String authHeader = exchange.getRequest().getHeaders().getFirst(AUTHORIZATION);
+		if (!isValidBearerToken(authHeader))
+			return handleUnauthorized(exchange, "Authorization 헤더가 없거나 올바르지 않음.");
+
+		String token = extractToken(authHeader);
+
+		// 캐시에서 먼저 토큰 유효성 확인
+		Map<String, Object> cachedClaims = cacheService.getFromCache(token);
+		if (isCacheAvailable(cachedClaims)) {
+			return processCachedToken(exchange, chain, token, cachedClaims);
+		}
+
+		// 캐시 미스 시 WebClient를 통해 토큰 검증 및 캐시에 저장
+		return authWebClient.validateToken("Bearer " + token)
+			.flatMap(claims -> saveToCacheAndProceed(exchange, chain, claims, token))
+			.onErrorResume(e -> handleTokenValidationFailure(exchange, e, token));
+	}
+
+	/**
+	 * 검증된 토큰 정보를 캐시에 저장한 후 필터 체인을 계속해서 진행합니다.
+	 *
+	 * @param exchange 서버 교환 객체
+	 * @param chain 필터 체인
+	 * @param claims 검증된 클레임 정보
+	 * @param token 저장할 JWT 토큰
+	 * @return 필터 체인 결과
+	 */
+	private Mono<Void> saveToCacheAndProceed(ServerWebExchange exchange, GatewayFilterChain chain,
+		Map<String, Object> claims, String token) {
+		cacheService.putInCache(token, claims);
+		log.info("토큰 검증 성공: {}, 캐시에 저장", token);
+		return handleSuccess(exchange, claims, chain);
+	}
+
+	/**
+	 * 캐시된 토큰 정보를 사용하여 필터 체인을 계속해서 진행합니다.
+	 *
+	 * @param exchange 서버 교환 객체
+	 * @param chain 필터 체인
+	 * @param token 캐시에 있는 JWT 토큰
+	 * @param cachedClaims 캐시된 클레임 정보
+	 * @return 필터 체인 결과
+	 */
+	private Mono<Void> processCachedToken(ServerWebExchange exchange, GatewayFilterChain chain, String token,
+		Map<String, Object> cachedClaims) {
+		log.info("토큰 캐시 히트: {}", token);
+		return handleSuccess(exchange, cachedClaims, chain);
+	}
+}

--- a/gateway-service/src/main/java/com/ticketing/gatewayservice/application/filter/DenyAccessGatewayFilter.java
+++ b/gateway-service/src/main/java/com/ticketing/gatewayservice/application/filter/DenyAccessGatewayFilter.java
@@ -1,0 +1,26 @@
+package com.ticketing.gatewayservice.application.filter;
+
+import static com.ticketing.gatewayservice.infrastructure.handler.AuthTokenResponseHandler.*;
+
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Order(-1)
+@Component
+@NoArgsConstructor
+@Slf4j
+public class DenyAccessGatewayFilter extends AbstractGatewayFilterFactory<Object> {
+
+	@Override
+	public GatewayFilter apply(Object config) {
+		return (exchange, chain) -> {
+			log.info("Handling forbidden access");
+			return handleForbiddenAccess(exchange);
+		};
+	}
+}

--- a/gateway-service/src/main/java/com/ticketing/gatewayservice/infrastructure/cache/CacheService.java
+++ b/gateway-service/src/main/java/com/ticketing/gatewayservice/infrastructure/cache/CacheService.java
@@ -1,0 +1,14 @@
+package com.ticketing.gatewayservice.infrastructure.cache;
+
+import java.util.Map;
+
+/**
+ * 캐시 관리 인터페이스.
+ * 다양한 캐시 구현체(Caffeine, Redis 등)를 지원하기 위한 추상화 레이어.
+ */
+public interface CacheService {
+
+	Map<String, Object> getFromCache(String token);
+
+	void putInCache(String token, Map<String, Object> claims);
+}

--- a/gateway-service/src/main/java/com/ticketing/gatewayservice/infrastructure/cache/CaffeineCacheService.java
+++ b/gateway-service/src/main/java/com/ticketing/gatewayservice/infrastructure/cache/CaffeineCacheService.java
@@ -1,0 +1,62 @@
+package com.ticketing.gatewayservice.infrastructure.cache;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Caffeine 기반의 캐시 관리 서비스입니다.
+ * 외부 환경 변수에서 캐시 만료 시간과 최대 크기를 주입받아 설정합니다.
+ */
+@Component
+@RequiredArgsConstructor
+public class CaffeineCacheService implements CacheService {
+
+	private final Cache<String, Map<String, Object>> localCache;
+	@Value("${cache.caffeine.expiration}")
+	private long expirationTime;  // 캐시 만료 시간
+	@Value("${cache.caffeine.max-size}")
+	private long maxSize;  // 캐시 최대 크기
+
+	/**
+	 * CaffeineCacheService의 생성자입니다.
+	 * 캐시 만료 시간과 크기를 외부 설정으로 받아 초기화합니다.
+	 */
+	public CaffeineCacheService() {
+		this.localCache = Caffeine.newBuilder()
+			.expireAfterWrite(expirationTime, TimeUnit.SECONDS)  // 캐시 만료 시간 설정
+			.maximumSize(maxSize)  // 캐시 최대 크기 설정
+			.build();
+	}
+
+	/**
+	 * 캐시에서 토큰에 해당하는 클레임 정보를 조회합니다.
+	 *
+	 * @param token 검증할 JWT 토큰
+	 * @return 캐시된 클레임 정보 또는 null
+	 */
+	@Override
+	public Map<String, Object> getFromCache(String token) {
+		return localCache.getIfPresent(token);  // 캐시에서 토큰 정보 조회
+	}
+
+	/**
+	 * 토큰과 해당 클레임 정보를 캐시에 저장합니다.
+	 *
+	 * @param token 캐시에 저장할 토큰
+	 * @param claims 토큰에 해당하는 클레임 정보
+	 */
+	@Override
+	public void putInCache(String token, Map<String, Object> claims) {
+		if (claims != null && !claims.isEmpty()) {
+			localCache.put(token, claims);  // 캐시에 저장
+		}
+	}
+}

--- a/gateway-service/src/test/java/com/ticketing/gatewayservice/application/filter/AuthTokenFilterTest.java
+++ b/gateway-service/src/test/java/com/ticketing/gatewayservice/application/filter/AuthTokenFilterTest.java
@@ -1,0 +1,113 @@
+package com.ticketing.gatewayservice.application.filter;
+
+import static com.ticketing.gatewayservice.infrastructure.helper.ArbitraryClaimsFactory.*;
+import static com.ticketing.gatewayservice.infrastructure.helper.ArbitraryExchangeFactory.*;
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ServerWebExchange;
+
+import com.ticketing.gatewayservice.infrastructure.cache.CacheService;
+import com.ticketing.gatewayservice.infrastructure.feign.AuthWebClient;
+
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+/**
+ * AuthTokenFilter의 주요 로직을 검증하는 테스트 클래스입니다.
+ */
+class AuthTokenFilterTest {
+
+	@Mock
+	private AuthWebClient authWebClient;
+
+	@Mock
+	private CacheService cacheService;
+
+	@Mock
+	private GatewayFilterChain chain;
+
+	@InjectMocks
+	private AuthTokenFilter authTokenFilter;
+
+	private ServerWebExchange exchange;
+
+	@BeforeEach
+	void setUp() {
+		MockitoAnnotations.openMocks(this);
+		exchange = anExchange();
+	}
+
+	/**
+	 * 캐시에 저장된 토큰을 사용하여 요청이 성공적으로 처리되는지 검증합니다.
+	 */
+	@Test
+	@DisplayName("캐시된_토큰이_있을때_요청이_성공적으로_처리")
+	void cachedToken_successfullyProcessesRequest() {
+		// Given: 캐시에 저장된 토큰 정보
+		Map<String, Object> cachedClaims = claims();
+
+		when(cacheService.getFromCache("mockToken")).thenReturn(cachedClaims);
+		when(chain.filter(exchange)).thenReturn(Mono.empty());
+
+		// When: 필터 실행
+		Mono<Void> result = authTokenFilter.filter(exchange, chain);
+
+		// Then: 필터 성공 검증
+		StepVerifier.create(result).verifyComplete();
+		assertThat(exchange.getResponse().getStatusCode(), is(HttpStatus.OK));
+	}
+
+	/**
+	 * 캐시 미스 시 AuthWebClient를 호출하고 성공적으로 처리되는지 검증합니다.
+	 */
+	@Test
+	@DisplayName("캐시미스_발생시_AuthWebClient_호출하여_성공적으로_처리")
+	void cacheMiss_triggersAuthWebClientCall_andSuccessfullyProcessesRequest() {
+		// Given: 캐시 미스 상황
+		when(cacheService.getFromCache("mockToken")).thenReturn(null);
+
+		// AuthWebClient가 성공적으로 토큰을 검증한 경우
+		Map<String, Object> claims = claims();
+
+		when(authWebClient.validateToken("Bearer mockToken")).thenReturn(Mono.just(claims));
+		when(chain.filter(exchange)).thenReturn(Mono.empty());
+
+		// When: 필터 실행
+		Mono<Void> result = authTokenFilter.filter(exchange, chain);
+
+		// Then: AuthWebClient 호출 후 성공 검증
+		StepVerifier.create(result).verifyComplete();
+		assertThat(exchange.getResponse().getStatusCode(), is(HttpStatus.OK));
+	}
+
+	/**
+	 * 유효하지 않은 토큰이 주어졌을 때 401 응답을 반환하는지 검증합니다.
+	 */
+	@Test
+	@DisplayName("유효하지_않은_토큰이_주어지면_401_응답_반환")
+	void invalidToken_returnsUnauthorized() {
+		// Given: 유효하지 않은 토큰
+		when(cacheService.getFromCache("mockToken")).thenReturn(null);
+		when(authWebClient.validateToken("Bearer mockToken")).thenReturn(
+			Mono.error(new RuntimeException("Unauthorized")));
+
+		// When: 필터 실행
+		Mono<Void> result = authTokenFilter.filter(exchange, chain);
+
+		// Then: 401 Unauthorized 상태가 반환되는지 검증
+		StepVerifier.create(result).verifyComplete();
+		assertThat(exchange.getResponse().getStatusCode(), is(HttpStatus.UNAUTHORIZED));
+	}
+}

--- a/gateway-service/src/test/java/com/ticketing/gatewayservice/application/filter/DenyAccessGatewayFilterTest.java
+++ b/gateway-service/src/test/java/com/ticketing/gatewayservice/application/filter/DenyAccessGatewayFilterTest.java
@@ -1,0 +1,37 @@
+package com.ticketing.gatewayservice.application.filter;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+public class DenyAccessGatewayFilterTest {
+
+	private WebTestClient webTestClient;
+
+	@LocalServerPort  // @SpringBootTest가 정의한 포트를 주입받습니다.
+	private int port;
+
+	@BeforeEach
+	void setUp() {
+		// 테스트 클라이언트를 수동으로 생성
+		this.webTestClient = WebTestClient.bindToServer()
+			.baseUrl("http://localhost:" + port)  // 로컬호스트와 지정된 포트를 이용해 테스트 클라이언트 생성
+			.build();
+	}
+
+	/**
+	 * DenyAccessGatewayFilter가 적용된 경로로 접근 시 403 Forbidden 응답을 반환하는지 테스트합니다.
+	 */
+	@Test
+	@DisplayName("DenyAccessGatewayFilter가 적용된 경로에서 403 응답 테스트")
+	void testDenyAccessFilter() {
+		webTestClient.get()
+			.uri("/api/v1/internal/test")  // DenyAccessGatewayFilter가 적용된 경로
+			.exchange()
+			.expectStatus().isForbidden();  // 403 응답 확인
+	}
+}

--- a/gateway-service/src/test/java/com/ticketing/gatewayservice/infrastructure/cache/CaffeineCacheServiceTest.java
+++ b/gateway-service/src/test/java/com/ticketing/gatewayservice/infrastructure/cache/CaffeineCacheServiceTest.java
@@ -1,0 +1,67 @@
+package com.ticketing.gatewayservice.infrastructure.cache;
+
+import static com.ticketing.gatewayservice.infrastructure.helper.ArbitraryClaimsFactory.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.github.benmanes.caffeine.cache.Cache;
+
+/**
+ * CaffeineCacheService의 캐시 저장 및 조회 로직을 검증하는 테스트 클래스입니다.
+ */
+class CaffeineCacheServiceTest {
+
+	@Mock
+	private Cache<String, Map<String, Object>> localCache;
+
+	@InjectMocks
+	private CaffeineCacheService caffeineCacheService;
+
+	@BeforeEach
+	void setUp() {
+		MockitoAnnotations.openMocks(this);
+	}
+
+	/**
+	 * 캐시에 저장된 토큰 클레임 정보를 성공적으로 반환하는지 검증합니다.
+	 */
+	@Test
+	@DisplayName("캐시에서_토큰_클레임_정보_성공적으로_반환")
+	void cachedClaims_areSuccessfullyReturned_fromCache() {
+		// Given: 캐시에 저장된 클레임 정보
+		Map<String, Object> cachedClaims = claims();
+
+		when(localCache.getIfPresent("mockToken")).thenReturn(cachedClaims);
+
+		// When: 캐시에서 토큰을 조회했을 때
+		Map<String, Object> result = caffeineCacheService.getFromCache("mockToken");
+
+		// Then: 캐시된 클레임 정보를 반환하는지 검증
+		assertEquals(cachedClaims, result);
+	}
+
+	/**
+	 * 토큰 클레임 정보를 캐시에 성공적으로 저장하는지 검증합니다.
+	 */
+	@Test
+	@DisplayName("클레임_정보를_캐시에_성공적으로_저장")
+	void tokenClaims_areSuccessfullyStored_inCache() {
+		// Given: 저장할 클레임 정보
+		Map<String, Object> claims = claims();
+
+		// When: 클레임 정보를 캐시에 저장했을 때
+		caffeineCacheService.putInCache("mockToken", claims);
+
+		// Then: 캐시에 저장되었는지 검증
+		verify(localCache).put("mockToken", claims);
+	}
+}

--- a/gateway-service/src/test/java/com/ticketing/gatewayservice/infrastructure/helper/ArbitraryClaimsFactory.java
+++ b/gateway-service/src/test/java/com/ticketing/gatewayservice/infrastructure/helper/ArbitraryClaimsFactory.java
@@ -1,0 +1,21 @@
+package com.ticketing.gatewayservice.infrastructure.helper;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 클레임 정보를 생성하는 헬퍼 클래스입니다.
+ */
+public class ArbitraryClaimsFactory {
+
+	/**
+	 * 캐시된 클레임 정보를 생성하는 헬퍼 메서드입니다.
+	 *
+	 * @return 생성된 클레임 정보 Map 객체
+	 */
+	public static Map<String, Object> claims() {
+		Map<String, Object> claims = new HashMap<>();
+		claims.put("user", "testUser");
+		return claims;
+	}
+}

--- a/gateway-service/src/test/java/com/ticketing/gatewayservice/infrastructure/helper/ArbitraryExchangeFactory.java
+++ b/gateway-service/src/test/java/com/ticketing/gatewayservice/infrastructure/helper/ArbitraryExchangeFactory.java
@@ -1,0 +1,27 @@
+package com.ticketing.gatewayservice.infrastructure.helper;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.web.server.ServerWebExchange;
+
+/**
+ * ServerWebExchange 객체 생성을 관리하는 헬퍼 클래스입니다.
+ */
+public class ArbitraryExchangeFactory {
+
+	/**
+	 * 테스트에 사용할 기본 ServerWebExchange 객체를 생성하는 헬퍼 메서드입니다.
+	 *
+	 * @return 생성된 ServerWebExchange 객체
+	 */
+	public static ServerWebExchange anExchange() {
+		ServerWebExchange exchange = anExchange("/api/v1/test");
+		exchange.getRequest().mutate().header(HttpHeaders.AUTHORIZATION, "Bearer mockToken").build();
+		return exchange;
+	}
+
+	private static ServerWebExchange anExchange(String uri) {
+		return MockServerWebExchange.from(MockServerHttpRequest.get(uri).build());
+	}
+}

--- a/gateway-service/src/test/resources/application.yml
+++ b/gateway-service/src/test/resources/application.yml
@@ -1,0 +1,36 @@
+server:
+  port: ${SERVER_PORT:19090}  # 기본값: 19090
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: ${ACTUATOR_ENDPOINTS:health,info}  # 기본값: health, info
+  endpoint:
+    health:
+      show-details: ${SHOW_HEALTH_DETAILS:always}  # 기본값: always
+
+spring:
+  cloud:
+    gateway:
+      routes:
+        - id: auth-service
+          uri: ${AUTH_SERVICE_URI:http://localhost:19093}
+          predicates:
+            - Path=/api/v1/auth/**
+        - id: internal-service
+          uri: ${INTERNAL_SERVICE_URI:http://localhost:19090}
+          predicates:
+            - Path=/api/v1/internal/**
+          filters:
+            - name: DenyAccessGatewayFilter  # 필터 추가
+
+# WebClient를 통해 호출하는 auth-service 설정
+auth-service:
+  name: ${AUTH_SERVICE_NAME:auth-service}  # 기본값: auth-service
+  url: ${AUTH_SERVICE_URL:http://localhost:19090}  # 기본값: http://localhost:19090
+
+cache:
+  caffeine:
+    expiration: ${CACHE_EXPIRATION:3600}  # 기본값: 3600초 (1시간)
+    max-size: ${CACHE_MAX_SIZE:1000}    # 기본값: 1000


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #48  
Closes #49  
Closes #50

## 📌 PR 요약

Caffeine 기반 캐시 서비스와 JWT 토큰 검증 필터를 추가하고, 특정 경로에 대한 접근을 제한하는 필터를 구현했습니다. 이와 함께, 각각의 기능에 대한 테스트 코드를 추가하여 캐시 서비스, 토큰 검증, 접근 제한 필터의 정상 작동을 검증했습니다.

## 🔍 주요 변경 사항

- **CaffeineCacheService 구현**
  - Caffeine 기반 캐시 서비스를 구현했습니다.
  - CacheService 인터페이스를 통해 캐시 서비스의 추상화 계층을 추가했습니다.
  - 캐시 만료 시간 및 캐시 크기를 외부 설정으로 관리할 수 있도록 구성했습니다.

- **CaffeineCacheService 테스트 코드 추가**
  - CaffeineCacheService에 대한 단위 테스트를 추가했습니다.
  - Mock 데이터를 사용하여 캐시 저장 및 조회에 대한 검증을 수행했습니다.

- **AuthTokenFilter 구현**
  - JWT 토큰을 검증하고, 유효한 경우 필터 체인을 계속해서 진행하는 필터를 구현했습니다.
  - 캐시를 먼저 확인하고, 없는 경우 Auth 서버에 요청하여 토큰을 검증합니다.

- **AuthTokenFilter 테스트 코드 추가**
  - AuthTokenFilter에 대한 단위 테스트를 추가했습니다.
  - Mock 데이터를 사용하여 캐시 히트, 캐시 미스, 유효하지 않은 토큰에 대한 검증을 수행했습니다.

- **DenyAccessGatewayFilter 구현**
  - 특정 경로에 대해 403 Forbidden 응답을 반환하는 필터를 구현했습니다.

- **DenyAccessGatewayFilter 테스트 코드 추가**
  - DenyAccessGatewayFilter에 대한 단위 테스트를 추가했습니다.
  - 필터가 정상적으로 403 응답을 반환하는지 검증하는 테스트를 작성했습니다.

## 🧪 테스트 방법

```bash
./gradlew test
```

## ✅ PR 체크리스트

- [x] 코드 컨벤션을 준수했나요?
- [x] 필요한 테스트를 추가하고 모든 테스트가 통과하나요?
- [ ] 관련 문서를 업데이트했나요? (필요한 경우)

## 👀 리뷰어 체크 포인트

- 인가 기능은 인가 모듈에서 구현 예정입니다
- 테스트 코드는 성공적인 webClient 통신을 가정하고 작성되었습니다.

## 💬 기타 코멘트
