### PR TITLE
✨ 유저 서비스 내부통신 API 및 dockerfile 추가

### DIFF
--- a/user-service/Dockerfile
+++ b/user-service/Dockerfile
@@ -1,0 +1,14 @@
+# 1. OpenJDK 베이스 이미지 사용
+FROM openjdk:17-jdk
+
+# 작성자 정보 추가
+LABEL authors="tellang"
+
+# 2. 작업 디렉토리 설정
+WORKDIR /ipho
+
+# 3. JAR 파일을 컨테이너로 복사
+COPY build/libs/user-service.jar /ipho/user-service.jar
+
+# 4. 애플리케이션 실행
+ENTRYPOINT ["java", "-jar", "/ipho/user-service.jar"]

--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -9,6 +9,7 @@ plugins {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
     runtimeOnly 'org.postgresql:postgresql'
 

--- a/user-service/src/main/java/com/ticketing/userservice/application/dto/UserDto.java
+++ b/user-service/src/main/java/com/ticketing/userservice/application/dto/UserDto.java
@@ -7,7 +7,27 @@ import com.ticketing.userservice.infrastructure.common.RoleType;
 import lombok.Builder;
 import lombok.With;
 
-public interface UserDto {
+public interface UserDto { //TODO: 공통모듈 적용시 통합
+
+	/**
+	 * Auth 관련 요청/응답을 담는 인터페이스입니다.
+	 */
+	interface Auth {
+
+		/**
+		 * 로그인 결과를 반환하는 DTO입니다. (readUserByEmail의 결과로 사용)
+		 *
+		 * @param id 사용자 ID
+		 * @param name 사용자 이름
+		 * @param email 사용자 이메일 주소
+		 * @param password 사용자 비밀번호 (해시된 비밀번호)
+		 * @param role 사용자 권한 정보
+		 */
+		@With
+		@Builder
+		record Result(Long id, String name, String email, String password, RoleType role) {
+		}
+	}
 
 	interface Delete {
 		@With

--- a/user-service/src/main/java/com/ticketing/userservice/application/dto/UserMapper.java
+++ b/user-service/src/main/java/com/ticketing/userservice/application/dto/UserMapper.java
@@ -27,6 +27,16 @@ public class UserMapper {
 			.build();
 	}
 
+	public static Auth.Result authDtoFrom(User user) {
+		return Auth.Result.builder()
+			.id(user.getId())
+			.name(user.getName())
+			.email(user.getEmail())
+			.role(user.getRole())
+			.password(user.getPassword())
+			.build();
+	}
+
 	public static Delete.Result deleteDtoFrom(User user) {
 		return Delete.Result.builder()
 			.id(user.getId())

--- a/user-service/src/main/java/com/ticketing/userservice/application/service/UserService.java
+++ b/user-service/src/main/java/com/ticketing/userservice/application/service/UserService.java
@@ -25,7 +25,7 @@ public class UserService {
 	private final RepositoryHelper<User, Long> repositoryHelper;
 
 	/**
-	 * 새로운 유저을 생성하는 메서드
+	 * 새로운 유저를 생성하는 메서드
 	 *
 	 * @param createDto 유저 생성 정보
 	 * @return 생성된 유저 결과
@@ -48,7 +48,7 @@ public class UserService {
 	}
 
 	/**
-	 * 모든 유저을 조회하는 내부 메서드 (관리자용)
+	 * 모든 유저를 조회하는 내부 메서드 (관리자용)
 	 *
 	 * @param pageable 페이징 정보
 	 * @return 페이징된 유저 결과
@@ -58,7 +58,7 @@ public class UserService {
 	}
 
 	/**
-	 * 유저을 삭제하는 메서드
+	 * 유저를 삭제하는 메서드
 	 *
 	 * @param id 삭제할 유저의 ID
 	 */

--- a/user-service/src/main/java/com/ticketing/userservice/application/service/UserService.java
+++ b/user-service/src/main/java/com/ticketing/userservice/application/service/UserService.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.ticketing.userservice.application.dto.UserDto;
 import com.ticketing.userservice.domain.User;
 import com.ticketing.userservice.domain.repository.UserRepository;
 import com.ticketing.userservice.domain.repository.helper.RepositoryHelper;
@@ -79,5 +80,15 @@ public class UserService {
 		User user = repositoryHelper.findOrThrowNotFound(deleteDto.id());
 		user.softDelete(deleteDto.deleterId());
 		return deleteDtoFrom(user);
+	}
+
+	/**
+	 * 이메일로 유저를 조회하는 메서드
+	 *
+	 * @param email 조회할 유저의 이메일
+	 * @return 유저 인증 정보 결과
+	 */
+	public UserDto.Auth.Result readUserByEmail(String email) {
+		return authDtoFrom(userRepository.findByEmail(email));
 	}
 }

--- a/user-service/src/main/java/com/ticketing/userservice/domain/repository/UserRepository.java
+++ b/user-service/src/main/java/com/ticketing/userservice/domain/repository/UserRepository.java
@@ -8,4 +8,7 @@ import com.ticketing.userservice.domain.User;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
+	User findByEmail(String email);
+
+	boolean existsByEmail(String email);
 }

--- a/user-service/src/main/java/com/ticketing/userservice/presentation/UserInternalController.java
+++ b/user-service/src/main/java/com/ticketing/userservice/presentation/UserInternalController.java
@@ -1,0 +1,50 @@
+package com.ticketing.userservice.presentation;
+
+import static com.ticketing.userservice.application.dto.UserDto.*;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ticketing.userservice.application.service.UserService;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 유저 관련 내부 API를 제공하는 컨트롤러 클래스입니다.
+ *
+ * - 새로운 유저 생성, 특정 유저 조회 등의 기능을 제공합니다.
+ */
+@RestController
+@RequestMapping("/api/v1/internal/users")
+@RequiredArgsConstructor
+public class UserInternalController {
+
+	private final UserService userService;
+
+	/**
+	 * 새로운 유저을 생성하는 엔드포인트입니다.
+	 *
+	 * @param dto 유저 생성 정보를 담은 DTO 객체
+	 * @return 생성된 유저 정보를 반환합니다.
+	 */
+	@PostMapping
+	public Result createUser(@RequestBody Create dto) {
+		return userService.createUser(dto);
+	}
+
+	/**
+	 * 특정 유저를 조회하는 엔드포인트입니다.
+	 *
+	 * @param email 조회할 유저의 이메일
+	 * @return 조회된 유저 정보를 반환합니다.
+	 */
+	@GetMapping
+	public Auth.Result readUserByEmail(@RequestParam String email) {
+		return userService.readUserByEmail(email);
+	}
+
+}

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -17,6 +17,7 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
+        globally_quoted_identifiers: true
         format_sql: true
         highlight_sql: true
 


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #62  
Closes #63

## 📌 PR 요약

- 내부 통신을 위한 DTO 및 매핑 메소드 추가
- 이메일로 유저 조회 기능 추가
- 내부 통신용 컨트롤러 추가
- `user-service`에 Dockerfile 및 `spring-boot-starter-actuator` 의존성 추가
- `user` 예약어 회피 설정 추가

## 🔍 주요 변경 사항

- `UserDto`에 `Auth.Result` 추가
- `UserMapper`에 `authDtoFrom` 메소드 추가
- `UserService`에 `readUserByEmail` 메소드 추가
- `UserRepository`에 이메일 조회 관련 메소드 추가
- `UserInternalController`에 유저 생성 및 조회 API 추가
- `user-service`에 Dockerfile 추가 및 health check를 위한 actuator 의존성 추가
- Hibernate `globally_quoted_identifiers` 속성 추가

## 🧪 테스트 방법

```bash
./gradlew test
```

## ✅ PR 체크리스트

- [x] 코드 컨벤션을 준수했나요?
- [x] 필요한 테스트를 추가하고 모든 테스트가 통과하나요?
- [ ] 관련 문서를 업데이트했나요? (필요한 경우)

## 👀 리뷰어 체크 포인트


## 💬 기타 코멘트

- 추후 통합 모듈로의 리팩토링이 예정되어 있습니다.
- 이메일 중복과 관련된 문제는 별도의 pr에서 다룹니다
- docker 관련 환경변수 파일은 slack 으로 공유하겠습니다