### PR TITLE
✨ 인증 서비스 토큰 검증 내부 통신 API 추가

### DIFF
--- a/auth-service/build.gradle
+++ b/auth-service/build.gradle
@@ -7,6 +7,9 @@ plugins {
 }
 
 dependencies {
+    // Spring WebFlux 의존성 추가
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
@@ -15,5 +18,8 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5' // Jackson을 사용해 JWT를 직렬화/역직렬화
+
+    // Reactor test support
+    testImplementation 'io.projectreactor:reactor-test'
 }
 

--- a/auth-service/src/main/java/com/ticketing/authservice/application/service/AuthService.java
+++ b/auth-service/src/main/java/com/ticketing/authservice/application/service/AuthService.java
@@ -13,7 +13,6 @@ import com.ticketing.authservice.infrastructure.security.BCryptUtil;
 import com.ticketing.authservice.infrastructure.security.JwtUtil;
 
 import lombok.RequiredArgsConstructor;
-import reactor.core.publisher.Mono;
 
 /**
  * AuthService는 회원가입 및 로그인과 관련된 비즈니스 로직을 처리하는 서비스입니다.
@@ -66,20 +65,11 @@ public class AuthService {
 	 * 전달된 JWT 토큰의 유효성을 확인하고, 유효한 경우 해당 토큰의 클레임 정보를 반환합니다.
 	 *
 	 * @param token 검증할 JWT 토큰
-	 * @return 토큰이 유효한 경우 클레임 정보를 포함한 Map을 반환하고,
-	 *         유효하지 않을 경우 Mono.error를 반환합니다.
+	 * @return 토큰이 유효한 경우 클레임 정보를 포함한 Map을 반환합니다.
 	 */
-	public Mono<Map<String, Object>> validateToken(String token) {
-		// JWT 유효성 검증
-		if (!jwtUtil.isTokenValid(token)) {
-			// 토큰이 유효하지 않은 경우 InvalidTokenException을 던집니다
-			return Mono.error(new InvalidTokenException(token));
-		}
-
-		// 유효한 토큰일 경우, 토큰에서 클레임 정보를 추출합니다
-		Map<String, Object> claims = jwtUtil.extractClaims(token);
-
-		// 추출한 클레임 정보를 Mono로 감싸서 반환합니다
-		return Mono.just(claims);
+	public Map<String, Object> validateToken(String token) {
+		// 토큰 유효성 검증과 클레임 추출을 한 번에 처리
+		return jwtUtil.validateAndExtractClaims(token)
+			.orElseThrow(() -> new InvalidTokenException(token));
 	}
 }

--- a/auth-service/src/main/java/com/ticketing/authservice/application/service/AuthService.java
+++ b/auth-service/src/main/java/com/ticketing/authservice/application/service/AuthService.java
@@ -2,6 +2,8 @@ package com.ticketing.authservice.application.service;
 
 import static com.ticketing.authservice.infrastructure.common.CustomException.*;
 
+import java.util.Map;
+
 import org.springframework.stereotype.Service;
 
 import com.ticketing.authservice.application.dto.UserDto;
@@ -11,6 +13,7 @@ import com.ticketing.authservice.infrastructure.security.BCryptUtil;
 import com.ticketing.authservice.infrastructure.security.JwtUtil;
 
 import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
 
 /**
  * AuthService는 회원가입 및 로그인과 관련된 비즈니스 로직을 처리하는 서비스입니다.
@@ -56,5 +59,27 @@ public class AuthService {
 
 		// JWT 토큰 생성
 		return jwtUtil.createToken(user.id(), user.email(), user.role().getAuthority());
+	}
+
+	/**
+	 * JWT 토큰을 검증하는 메서드입니다.
+	 * 전달된 JWT 토큰의 유효성을 확인하고, 유효한 경우 해당 토큰의 클레임 정보를 반환합니다.
+	 *
+	 * @param token 검증할 JWT 토큰
+	 * @return 토큰이 유효한 경우 클레임 정보를 포함한 Map을 반환하고,
+	 *         유효하지 않을 경우 Mono.error를 반환합니다.
+	 */
+	public Mono<Map<String, Object>> validateToken(String token) {
+		// JWT 유효성 검증
+		if (!jwtUtil.isTokenValid(token)) {
+			// 토큰이 유효하지 않은 경우 InvalidTokenException을 던집니다
+			return Mono.error(new InvalidTokenException(token));
+		}
+
+		// 유효한 토큰일 경우, 토큰에서 클레임 정보를 추출합니다
+		Map<String, Object> claims = jwtUtil.extractClaims(token);
+
+		// 추출한 클레임 정보를 Mono로 감싸서 반환합니다
+		return Mono.just(claims);
 	}
 }

--- a/auth-service/src/main/java/com/ticketing/authservice/infrastructure/common/CustomException.java
+++ b/auth-service/src/main/java/com/ticketing/authservice/infrastructure/common/CustomException.java
@@ -80,4 +80,20 @@ public class CustomException extends RuntimeException {
 				String.format("Password mismatch for User UUID (%s)", userId.toString()));
 		}
 	}
+
+	/**
+	 * JWT 토큰이 유효하지 않을 때 발생하는 예외 클래스입니다.
+	 */
+	@Getter
+	public static class InvalidTokenException extends CustomException {
+
+		/**
+		 * 토큰이 유효하지 않을 때 발생하는 예외.
+		 *
+		 * @param token 유효하지 않은 JWT 토큰
+		 */
+		public InvalidTokenException(String token) {
+			super(ErrorCode.INVALID_TOKEN, String.format("Invalid token: %s", token));
+		}
+	}
 }

--- a/auth-service/src/main/java/com/ticketing/authservice/infrastructure/common/codes/ErrorCode.java
+++ b/auth-service/src/main/java/com/ticketing/authservice/infrastructure/common/codes/ErrorCode.java
@@ -29,6 +29,8 @@ public enum ErrorCode implements ResponseCode, Serializable { //TODO: 공통 모
 	// 비밀번호 불일치
 	PASSWORD_MISMATCH(HttpStatus.UNAUTHORIZED, "A001", "Invalid password"),
 
+	// 유효하지 않은 토큰
+	INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A002", "Invalid token"),
 	; // End
 
 	/**

--- a/auth-service/src/main/java/com/ticketing/authservice/infrastructure/security/JwtUtil.java
+++ b/auth-service/src/main/java/com/ticketing/authservice/infrastructure/security/JwtUtil.java
@@ -1,6 +1,8 @@
 package com.ticketing.authservice.infrastructure.security;
 
 import java.util.Date;
+import java.util.Map;
+import java.util.Optional;
 
 import javax.crypto.SecretKey;
 
@@ -76,5 +78,20 @@ public class JwtUtil {
 		} catch (Exception e) {
 			return false;
 		}
+	}
+
+	/**
+	 * JWT 토큰의 유효성을 검증하고, 유효한 경우 해당 토큰의 클레임 정보를 추출하는 메서드입니다.
+	 *
+	 * @param token 검증할 JWT 토큰
+	 * @return 토큰이 유효한 경우 클레임 정보를 포함한 Optional을 반환하며, 유효하지 않은 경우 빈 Optional을 반환합니다.
+	 */
+	public Optional<Map<String, Object>> validateAndExtractClaims(String token) {
+		// 토큰 유효성 검증
+		if (!isTokenValid(token)) {
+			return Optional.empty(); // 토큰이 유효하지 않으면 빈 Optional 반환
+		}
+		// 유효한 토큰일 경우 클레임 정보 반환
+		return Optional.of(extractClaims(token));
 	}
 }

--- a/auth-service/src/main/java/com/ticketing/authservice/presentation/controller/AuthInternalController.java
+++ b/auth-service/src/main/java/com/ticketing/authservice/presentation/controller/AuthInternalController.java
@@ -10,7 +10,6 @@ import org.springframework.web.bind.annotation.RestController;
 import com.ticketing.authservice.application.service.AuthService;
 
 import lombok.RequiredArgsConstructor;
-import reactor.core.publisher.Mono;
 
 /**
  * 내부 시스템에서 인증 관련 요청을 처리하는 컨트롤러입니다.
@@ -31,7 +30,7 @@ public class AuthInternalController {
 	 * @return 검증된 클레임 정보
 	 */
 	@GetMapping("/validate")
-	public Mono<Map<String, Object>> validateToken(@RequestHeader("Authorization") String token) {
+	public Map<String, Object> validateToken(@RequestHeader("Authorization") String token) {
 		return authService.validateToken(token);
 	}
 }

--- a/auth-service/src/main/java/com/ticketing/authservice/presentation/controller/AuthInternalController.java
+++ b/auth-service/src/main/java/com/ticketing/authservice/presentation/controller/AuthInternalController.java
@@ -1,0 +1,37 @@
+package com.ticketing.authservice.presentation.controller;
+
+import java.util.Map;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ticketing.authservice.application.service.AuthService;
+
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
+
+/**
+ * 내부 시스템에서 인증 관련 요청을 처리하는 컨트롤러입니다.
+ * Auth 서버와의 통신을 통해 JWT 토큰을 검증하는 등의 기능을 제공합니다.
+ */
+@RestController
+@RequestMapping("api/v1/internal/auth")
+@RequiredArgsConstructor
+public class AuthInternalController {
+
+	private final AuthService authService;
+
+	/**
+	 * JWT 토큰을 검증하는 엔드포인트입니다.
+	 * 요청 헤더에서 전달된 토큰을 Auth 서버에 전달하여 검증한 후, 검증된 클레임 정보를 반환합니다.
+	 *
+	 * @param token 검증할 JWT 토큰
+	 * @return 검증된 클레임 정보
+	 */
+	@GetMapping("/validate")
+	public Mono<Map<String, Object>> validateToken(@RequestHeader("Authorization") String token) {
+		return authService.validateToken(token);
+	}
+}

--- a/auth-service/src/test/java/com/ticketing/authservice/application/service/AuthServiceTest.java
+++ b/auth-service/src/test/java/com/ticketing/authservice/application/service/AuthServiceTest.java
@@ -20,12 +20,8 @@ import org.mockito.Mock;
 import com.ticketing.authservice.application.dto.UserDto;
 import com.ticketing.authservice.application.mapper.AuthDataMapper;
 import com.ticketing.authservice.infrastructure.client.UserFeignService;
-import com.ticketing.authservice.infrastructure.common.CustomException.*;
 import com.ticketing.authservice.infrastructure.security.BCryptUtil;
 import com.ticketing.authservice.infrastructure.security.JwtUtil;
-
-import reactor.core.publisher.Mono;
-import reactor.test.StepVerifier;
 
 /**
  * {@code AuthServiceTest}는 {@code AuthService}의 회원 인증과 관련된
@@ -110,17 +106,13 @@ class AuthServiceTest {
 		String validToken = jwtUtil.createToken(USER_ID, USER_EMAIL, USER_ROLE.getAuthority());
 
 		// When: 토큰 검증 처리
-		Mono<Map<String, Object>> result = authService.validateToken(validToken);
+		Map<String, Object> claims = authService.validateToken(validToken);
 
 		// Then: 클레임 정보가 성공적으로 반환되었는지 확인
-		StepVerifier.create(result)
-			.assertNext(returnedClaims -> {
-				assertThat(returnedClaims.get("sub"), is(USER_ID.toString()));
-				assertThat(returnedClaims.get("email"), is(USER_EMAIL));
-				assertThat(returnedClaims.get("role"), is(USER_ROLE.getAuthority()));
-				// iat, exp 등은 검증하지 않음
-			})
-			.verifyComplete();
+		assertThat(claims.get("sub"), is(USER_ID.toString()));
+		assertThat(claims.get("email"), is(USER_EMAIL));
+		assertThat(claims.get("role"), is(USER_ROLE.getAuthority()));
+		// iat, exp 등은 검증하지 않음
 	}
 
 	/**
@@ -134,9 +126,6 @@ class AuthServiceTest {
 		String invalidToken = "invalidToken";
 
 		// When & Then: InvalidTokenException 발생 여부 확인
-		Mono<Map<String, Object>> result = authService.validateToken(invalidToken);
-		StepVerifier.create(result)
-			.expectError(InvalidTokenException.class)
-			.verify();
+		assertThrows(InvalidTokenException.class, () -> authService.validateToken(invalidToken));
 	}
 }


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #68

## 📌 PR 요약

- JWT 토큰 검증 기능 추가 및 관련 예외 처리 기능 구현

## 🔍 주요 변경 사항

- `CustomException`에 `InvalidTokenException` 클래스 추가
  - `ErrorCode`에 `INVALID_TOKEN` 코드 및 메시지 추가
- `AuthService`에 JWT 토큰 검증 로직 추가
  - `AuthInternalController`에 JWT 검증 엔드포인트 추가
  - `build.gradle`에 Spring WebFlux 및 Reactor 테스트 의존성 추가
- `AuthServiceTest`에 JWT 토큰 검증 테스트 케이스 추가

## 🧪 테스트 방법
```bash
./gradlew test
```

## ✅ PR 체크리스트

- [x] 코드 컨벤션을 준수했나요?
- [x] 필요한 테스트를 추가하고 모든 테스트가 통과하나요?
- [ ] 관련 문서를 업데이트했나요? (필요한 경우)

## 👀 리뷰어 체크 포인트


## 💬 기타 코멘트

- 공통 모듈로 통합 예정인 코드가 있습니다
  - 예외 처리 핸들링의 경우 공통 모듈 통합시 적용예정입니다
