### PR TITLE
✨ 게이트웨이에서 헤더에 인가에 필요한 정보 추가

### DIFF
--- a/gateway-service/src/main/java/com/ticketing/gatewayservice/application/filter/AuthTokenFilter.java
+++ b/gateway-service/src/main/java/com/ticketing/gatewayservice/application/filter/AuthTokenFilter.java
@@ -42,11 +42,19 @@ public class AuthTokenFilter implements GlobalFilter {
 	@Override
 	public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
 		String requestPath = exchange.getRequest().getURI().getPath();
+		String method = exchange.getRequest().getMethod().name();
+
 
 		// auth 관련 경로 회피 (로그인, 회원가입 등)
 		if (requestPath.startsWith("/api/v1/auth/")) {
 			log.info("Auth 관련 요청 - 토큰 검증 회피: {}", requestPath);
 			return chain.filter(exchange);  // 필터를 적용하지 않고 바로 다음 체인으로 이동
+		}
+
+		// /api/v1/events로 시작하는 GET 요청에 대해서 토큰 검증을 생략
+		if (requestPath.startsWith("/api/v1/events") && "GET".equalsIgnoreCase(method)) {
+			log.info("이벤트 관련 GET 요청 - 토큰 검증 회피: {}", requestPath);
+			return chain.filter(exchange);
 		}
 
 		String authHeader = exchange.getRequest().getHeaders().getFirst(AUTHORIZATION);

--- a/gateway-service/src/main/java/com/ticketing/gatewayservice/infrastructure/cache/CaffeineCacheService.java
+++ b/gateway-service/src/main/java/com/ticketing/gatewayservice/infrastructure/cache/CaffeineCacheService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 
 /**
@@ -19,7 +20,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class CaffeineCacheService implements CacheService {
 
-	private final Cache<String, Map<String, Object>> localCache;
+	private Cache<String, Map<String, Object>> localCache;
 	@Value("${cache.caffeine.expiration}")
 	private long expirationTime;  // 캐시 만료 시간
 	@Value("${cache.caffeine.max-size}")
@@ -29,7 +30,9 @@ public class CaffeineCacheService implements CacheService {
 	 * CaffeineCacheService의 생성자입니다.
 	 * 캐시 만료 시간과 크기를 외부 설정으로 받아 초기화합니다.
 	 */
-	public CaffeineCacheService() {
+	@PostConstruct
+	public void initCache() {
+
 		this.localCache = Caffeine.newBuilder()
 			.expireAfterWrite(expirationTime, TimeUnit.SECONDS)  // 캐시 만료 시간 설정
 			.maximumSize(maxSize)  // 캐시 최대 크기 설정

--- a/gateway-service/src/main/java/com/ticketing/gatewayservice/infrastructure/handler/AuthTokenResponseHandler.java
+++ b/gateway-service/src/main/java/com/ticketing/gatewayservice/infrastructure/handler/AuthTokenResponseHandler.java
@@ -26,6 +26,8 @@ public class AuthTokenResponseHandler {
 	 */
 	public static Mono<Void> handleSuccess(ServerWebExchange exchange, Map<String, Object> claims,
 		GatewayFilterChain chain) {
+		// 헤더에 유저 정보 추가
+		addHeadersToRequest(exchange, claims);
 		exchange.getResponse().setStatusCode(HttpStatus.OK);  // 응답 상태 200 설정
 		return chain.filter(exchange);
 	}
@@ -66,5 +68,24 @@ public class AuthTokenResponseHandler {
 	public static Mono<Void> handleForbiddenAccess(ServerWebExchange exchange) {
 		exchange.getResponse().setStatusCode(HttpStatus.FORBIDDEN);
 		return exchange.getResponse().setComplete();
+	}
+
+	/**
+	 * 요청의 헤더에 JWT 클레임 정보를 추가하는 메서드입니다.
+	 * <p>
+	 * JWT 토큰에서 추출된 사용자 ID, 이메일, 역할 정보를 HTTP 요청 헤더에 추가하여,
+	 * 이후 서비스 레이어에서 해당 정보를 사용할 수 있도록 합니다.
+	 * 추가된 헤더는 X-User-Id, X-Email, X-Role로 전달됩니다.
+	 *
+	 * @param exchange 서버 교환 객체 (요청 및 응답 정보를 포함)
+	 * @param claims JWT에서 추출한 클레임 정보 (사용자 ID, 이메일, 역할 등)
+	 */
+	private static void addHeadersToRequest(ServerWebExchange exchange, Map<String, Object> claims) {
+		exchange.getRequest()
+			.mutate()
+			.header("X-User-Id", claims.get("sub").toString())   // 사용자 ID를 헤더에 추가
+			.header("X-Email", claims.get("email").toString())   // 이메일을 헤더에 추가
+			.header("X-Role", claims.get("role").toString())     // 역할 정보를 헤더에 추가
+			.build();
 	}
 }


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #132 
Closes #134 

## 📌 PR 요약

- JWT 클레임 정보를 HTTP 요청 헤더에 추가 
- 특정 이벤트 관련 GET 요청에서 토큰 검증을 생략하는 로직을 추가
- 토큰이 저장되지 않던 버그 수정

## 🔍 주요 변경 사항

- `AuthTokenResponseHandler`에 JWT 클레임 정보를 HTTP 요청 헤더에 추가
  - `addHeadersToRequest` 메서드 추가
    - 헤더에 사용자 ID, 이메일, 역할 정보를 추가 (`X-User-Id`, `X-Email`, `X-Role`)
   
- `AuthTokenFilter`에 이벤트 관련 GET 요청에서 토큰 검증 회피 로직 추가
  - `/api/v1/events`로 시작하는 GET 요청에 대해 토큰 검증을 생략

- `CaffeineCacheService`의 캐시 초기화 로직 변경

## 🧪 테스트 방법


## ✅ PR 체크리스트

- [x] 코드 컨벤션을 준수했나요?
- [ ] 필요한 테스트를 추가하고 모든 테스트가 통과하나요?
- [ ] 관련 문서를 업데이트했나요? (필요한 경우)

## 👀 리뷰어 체크 포인트
